### PR TITLE
Add merge intervals algorithm and tests

### DIFF
--- a/src/leetcode_algorithms.py
+++ b/src/leetcode_algorithms.py
@@ -269,3 +269,39 @@ def valid_palindrome(s: str) -> bool:
     filtered = [ch.lower() for ch in s if ch.isalnum()]
     return filtered == filtered[::-1]
 
+
+def merge_intervals(intervals: List[List[int]]) -> List[List[int]]:
+    """Merge overlapping intervals and return the resulting list.
+
+    The intervals are first sorted by start time. Each interval is then either
+    appended to the ``merged`` list if it does not overlap with the previous
+    interval or used to extend the last interval in ``merged``.
+
+    Parameters
+    ----------
+    intervals:
+        A list of ``[start, end]`` pairs where ``start <= end``.
+
+    Returns
+    -------
+    List[List[int]]
+        The merged list of intervals sorted by start time.
+    """
+
+    if not intervals:
+        return []
+
+    # Sort intervals by their start values to simplify merging.
+    intervals.sort(key=lambda i: i[0])
+
+    merged: List[List[int]] = [intervals[0][:]]
+    for start, end in intervals[1:]:
+        last_end = merged[-1][1]
+        if start <= last_end:
+            # Overlapping intervals, extend the last interval.
+            merged[-1][1] = max(last_end, end)
+        else:
+            # Disjoint interval, append as new interval.
+            merged.append([start, end])
+    return merged
+

--- a/tests/test_leetcode_algorithms.py
+++ b/tests/test_leetcode_algorithms.py
@@ -17,6 +17,7 @@ from leetcode_algorithms import (
     pascal_triangle,
     max_profit,
     valid_palindrome,
+    merge_intervals,
 )
 
 
@@ -66,3 +67,8 @@ def test_max_profit():
 def test_valid_palindrome():
     assert valid_palindrome("A man, a plan, a canal: Panama")
     assert not valid_palindrome("race a car")
+
+
+def test_merge_intervals():
+    assert merge_intervals([[1, 3], [2, 6], [8, 10], [15, 18]]) == [[1, 6], [8, 10], [15, 18]]
+    assert merge_intervals([[1, 4], [4, 5]]) == [[1, 5]]


### PR DESCRIPTION
## Summary
- add merge_intervals function to handle overlapping interval ranges
- cover interval merging logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e31f389c8332b6c0ac9845ef8982